### PR TITLE
add end point for get community members

### DIFF
--- a/Sources/App/Controllers/MeetupController.swift
+++ b/Sources/App/Controllers/MeetupController.swift
@@ -11,7 +11,7 @@ import Fluent
 struct MeetupController: RouteCollection {
     
     func boot(router: Router) throws {
-        let publicRoutes = router.grouped("api", "meetup")
+        let publicRoutes = router.grouped("meetup")
         publicRoutes.get("currentSpeakers", use: currentSpeakers)
         publicRoutes.get("currentMeetup", use: currentMeetup)
         publicRoutes.get("currentTalks", use: currentTalks)

--- a/Sources/App/Controllers/ProfileController.swift
+++ b/Sources/App/Controllers/ProfileController.swift
@@ -1,0 +1,22 @@
+//
+//  ProfileController.swift
+//  App
+//
+//  Created by  LaptopGCampos on 8/23/18.
+//
+
+import Vapor
+import FluentPostgreSQL
+
+struct ProfileController: RouteCollection {
+    
+    func boot(router: Router) throws {
+        let publicRoutes = router.grouped("profile")
+        publicRoutes.get("communityMembers", use: communityMembers)
+    }
+    
+    func communityMembers(_ request: Request) throws -> Future<[Profile]> {
+        return Profile.profiles(ofType: .community, on: request)
+        
+    }
+}

--- a/Sources/App/Extensions/Router+Extension.swift
+++ b/Sources/App/Extensions/Router+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  Router+Extension.swift
+//  App
+//
+//  Created by  LaptopGCampos on 8/23/18.
+//
+
+import Vapor
+
+extension Router {
+    func register(collection: RouteCollection...) throws {
+        try collection.forEach { try $0.boot(router: self) }
+    }
+}

--- a/Sources/App/Models/Models+Data/Profile+Data.swift
+++ b/Sources/App/Models/Models+Data/Profile+Data.swift
@@ -1,0 +1,19 @@
+//
+//  Profile+Data.swift
+//  App
+//
+//  Created by  LaptopGCampos on 8/23/18.
+//
+
+import Vapor
+import FluentPostgreSQL
+
+extension Profile {
+    
+    static func profiles(ofType type: ProfileTypes, on request: Request) -> Future<[Profile]> {
+        return ProfileType.query(on: request).filter(\.id == type.rawValue)
+            .unwrapFirst(or: Abort(.notFound))
+            .flatMap { try $0.profiles.query(on: request).all() }
+            .checkEmpty(or: Abort(.notFound))
+    }
+}

--- a/Sources/App/Models/ProfileType.swift
+++ b/Sources/App/Models/ProfileType.swift
@@ -10,7 +10,7 @@ import FluentPostgreSQL
 enum ProfileTypes: Int {
     case speaker = 1
     case admin
-    case communityMember
+    case community
 }
 
 struct ProfileType: PostgreSQLModel {

--- a/Sources/App/Models/Seeds/Development/ProfileCommunitySeed.swift
+++ b/Sources/App/Models/Seeds/Development/ProfileCommunitySeed.swift
@@ -1,20 +1,20 @@
 //
-//  Profile_ProfileTypeSeed.swift
+//  ProfileCommunitySeed.swift
 //  App
 //
-//  Created by  LaptopGCampos on 7/11/18.
+//  Created by  LaptopGCampos on 8/23/18.
 //
 
 import FluentPostgreSQL
 import Vapor
 
-struct ProfileTypePivotSeed: Migration {
-
+struct ProfileCommunitySeed: Migration {
+    
     typealias Database = PostgreSQLDatabase
     
     static func prepare(on conn: PostgreSQLConnection) -> Future<Void> {
         return Profile.query(on: conn).unwrapFirst(or: Abort(.notFound, reason: "there is no profiles")).flatMap { profile -> Future<ProfileTypePivot> in
-            return try ProfileTypePivot(id: nil, profileId: profile.requireID(), profileTypeId: ProfileTypes.speaker.rawValue, createdAt: nil).save(on: conn)
+            return try ProfileTypePivot(id: nil, profileId: profile.requireID(), profileTypeId: ProfileTypes.community.rawValue, createdAt: nil).save(on: conn)
             }.toVoid()
     }
     

--- a/Sources/App/Models/Seeds/Development/ProfileTypeSeed.swift
+++ b/Sources/App/Models/Seeds/Development/ProfileTypeSeed.swift
@@ -12,8 +12,22 @@ struct ProfileTypeSeed: Migration {
     typealias Database = PostgreSQLDatabase
     
     static func prepare(on conn: PostgreSQLConnection) -> Future<Void> {
-        let profileType = ProfileType(id: nil, name: "Speaker", createdAt: nil)
-        return profileType.save(on: conn).toVoid()
+        let profileType = [ProfileType(id: nil, name: "Speaker", createdAt: nil).save(on: conn), ProfileType(id: nil, name: "Administrator", createdAt: nil).save(on: conn), ProfileType(id: nil, name: "Community", createdAt: nil).save(on: conn)]
+        return profileType.flatten(on: conn).toVoid()
+    }
+    
+    static func revert(on conn: PostgreSQLConnection) -> EventLoopFuture<Void> {
+        return .done(on: conn)
+    }
+}
+
+struct ProfileMoreTypesSeed: Migration {
+    
+    typealias Database = PostgreSQLDatabase
+    
+    static func prepare(on conn: PostgreSQLConnection) -> Future<Void> {
+        let profileType = [ProfileType(id: nil, name: "Administrator", createdAt: nil).save(on: conn), ProfileType(id: nil, name: "Community", createdAt: nil).save(on: conn)]
+        return profileType.flatten(on: conn).toVoid()
     }
     
     static func revert(on conn: PostgreSQLConnection) -> EventLoopFuture<Void> {

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -38,17 +38,18 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
     migrations.add(model: Profile.self, database: .psql)
     migrations.add(model: ProfileTypePivot.self, database: .psql)
     migrations.add(model: Talk.self, database: .psql)
-   
-    /// Seeds
     
+    /// Seeds
     migrations.add(migration: MeetupStatusSeed.self, database: .psql)
+    migrations.add(migration: ProfileTypeSeed.self, database: .psql)
+    migrations.add(migration: ProfileMoreTypesSeed.self, database: .psql)
     
     if env == .development  {
         migrations.add(migration: MeetupSeed.self, database: .psql)
-        migrations.add(migration: ProfileTypeSeed.self, database: .psql)
         migrations.add(migration: ProfileSeed.self, database: .psql)
         migrations.add(migration: ProfileTypePivotSeed.self, database: .psql)
         migrations.add(migration: TalkSeed.self, database: .psql)
+        migrations.add(migration: ProfileCommunitySeed.self, database: .psql)
     }
     
     services.register(migrations)

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -3,7 +3,10 @@ import Vapor
 /// Register your application's routes here.
 public func routes(_ router: Router) throws {
 
-    let meetupController = MeetupController()
+    let routeGrouped = router.grouped("api")
     
-    try router.register(collection: meetupController)
+    let meetupController = MeetupController()
+    let profileController = ProfileController()
+    
+    try routeGrouped.register(collection: meetupController, profileController)
 }

--- a/Tests/AppTests/ProfileControllerTest.swift
+++ b/Tests/AppTests/ProfileControllerTest.swift
@@ -1,0 +1,38 @@
+//
+//  ProfileControllerTest.swift
+//  App
+//
+//  Created by  LaptopGCampos on 8/23/18.
+//
+
+@testable import App
+import XCTest
+import Vapor
+import FluentPostgreSQL
+
+final class ProfileControllerTest: BaseTest {
+    
+    func testGetCommunityMembers() throws {
+        let profiles = try app.getRequest(to: "/api/profile/communityMembers", method: .GET, decodeTo: [Profile].self)
+        dump(profiles)
+        XCTAssertEqual(profiles.count, 1)
+        XCTAssertEqual(profiles.first?.email, "guseducampos@gmail.com")
+        XCTAssertEqual(profiles.first?.name, "Gustavo")
+    }
+    
+    func testEmptyCommunityMembers() throws {
+        _ = try ProfileTypePivot.query(on: conn)
+            .filter(\.profileTypeId == ProfileTypes.community.rawValue)
+            .unwrapFirst(or: Abort(.notFound))
+            .delete(on: conn).wait()
+        let response = try app.sendRequest(to: "/api/profile/communityMember", method: .GET)
+        XCTAssertEqual(response.http.status.code, 404)
+        try reset()
+    }
+    
+    static let allTests = [
+        ("testGetCommunityMembers", testGetCommunityMembers),
+        ("testEmptyCommunityMembers", testEmptyCommunityMembers)
+    ]
+}
+

--- a/Tests/AppTests/TestConfigure.swift
+++ b/Tests/AppTests/TestConfigure.swift
@@ -59,6 +59,8 @@ public func testConfigure(_ config: inout Config,
     migrations.add(migration: ProfileSeed.self, database: .psql)
     migrations.add(migration: ProfileTypePivotSeed.self, database: .psql)
     migrations.add(migration: TalkSeed.self, database: .psql)
+    migrations.add(migration: ProfileMoreTypesSeed.self, database: .psql)
+    migrations.add(migration: ProfileCommunitySeed.self, database: .psql)
     
     var commandConfig = CommandConfig.default()
     commandConfig.useFluentCommands()

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,5 +3,6 @@ import XCTest
 @testable import AppTests
 
 XCTMain([
-    testCase(MeetupTest.allTests)
+    testCase(MeetupTest.allTests),
+    testCase(ProfileControllerTest.allTests)
 ])


### PR DESCRIPTION
This PR solves issue #8 also this adds more migrations for profile types (this wasn't added on the same seed just for doesn't create database breaks since vapor can't identify whether a new thing was added on the same type because the lack of reflection on swift. 